### PR TITLE
security update

### DIFF
--- a/.github/workflows/ansible-lint.yaml
+++ b/.github/workflows/ansible-lint.yaml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Run ansible-lint
-        uses: ansible/ansible-lint@main
+        uses: ansible/ansible-lint@e918e02374cc9148abfe6d0fa04417ee89f0def9
         with:
           args: ""
           setup_python: "true"

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 .vscode/
 vars.yaml
+
+# KICS
+results.json


### PR DESCRIPTION
- replaced ansible-lint workflow version with commit SHA
- updated `.gitignore` to skip [KICS](https://github.com/Checkmarx/kics/blob/master/docs/getting-started.md) results file